### PR TITLE
Add CCHH_ prefix to environment variables and remove ZUNDA_SPEAK_SPEED

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,26 +166,26 @@ cchh/
 ### Environment Variables
 
 #### Slack Configuration
-- `SLACK_BOT_TOKEN`: Slack Bot Token (xoxb-...)
-- `SLACK_CHANNEL_ID`: Notification channel ID
-- `SLACK_NOTIFICATIONS_ENABLED`: Enable/disable Slack notifications (default: true)
-- `SLACK_SHOW_SESSION_START`: Show cwd on session start (default: true)
-- `SLACK_NOTIFY_ON_TOOL_USE`: Notify on tool usage (default: true)
-- `SLACK_NOTIFY_ON_STOP`: Notify on stop events (default: true)
-- `SLACK_COMMAND_MAX_LENGTH`: Max command display length (default: 200)
+- `CCHH_SLACK_BOT_TOKEN`: Slack Bot Token (xoxb-...)
+- `CCHH_SLACK_CHANNEL_ID`: Notification channel ID
+- `CCHH_SLACK_NOTIFICATIONS_ENABLED`: Enable/disable Slack notifications (default: true)
+- `CCHH_SLACK_SHOW_SESSION_START`: Show cwd on session start (default: true)
+- `CCHH_SLACK_NOTIFY_ON_TOOL_USE`: Notify on tool usage (default: true)
+- `CCHH_SLACK_NOTIFY_ON_STOP`: Notify on stop events (default: true)
+- `CCHH_SLACK_COMMAND_MAX_LENGTH`: Max command display length (default: 200)
 
 #### Zunda Voice Configuration
-- `ZUNDA_SPEAKER_ENABLED`: Enable/disable voice feedback (default: true)
-- `ZUNDA_SPEAK_ON_PROMPT_SUBMIT`: Speak on prompt submit (default: true)
-- `ZUNDA_SPEAK_SPEED`: Speech speed (default: 1.2)
+- `CCHH_ZUNDA_SPEAKER_ENABLED`: Enable/disable voice feedback (default: true)
+- `CCHH_ZUNDA_SPEAK_ON_PROMPT_SUBMIT`: Speak on prompt submit (default: true)
 
 #### Event Logging Configuration
-- `EVENT_LOGGING_ENABLED`: Enable/disable event logging (default: true)
-- `LOG_MAX_SIZE_MB`: Max log file size in MB (default: 100)
-- `LOG_ROTATION_COUNT`: Log rotation count (default: 5)
+- `CCHH_EVENT_LOGGING_ENABLED`: Enable/disable event logging (default: true)
+- `CCHH_LOG_MAX_SIZE_MB`: Max log file size in MB (default: 100)
+- `CCHH_LOG_ROTATION_COUNT`: Log rotation count (default: 5)
 
 #### Other
-- `TEST_ENVIRONMENT`: Test environment flag (disables notifications during tests)
+- `CCHH_TEST_ENVIRONMENT`: Test environment flag (disables notifications during tests)
+- `CCHH_CLAUDE_SESSION_ID`: Claude session ID
 
 ## Code Quality Configuration
 
@@ -307,11 +307,11 @@ Add to Claude Code settings (`~/.claude/settings.json`):
 
 ### Common Issues
 1. **Import errors**: Ensure PYTHONPATH includes project root
-2. **Slack not working**: Check SLACK_BOT_TOKEN and SLACK_CHANNEL_ID
+2. **Slack not working**: Check CCHH_SLACK_BOT_TOKEN and CCHH_SLACK_CHANNEL_ID
 3. **Tests failing**: Run `uv sync` to update dependencies
 
 ### Debug Mode
-Set `TEST_ENVIRONMENT=1` to disable external notifications during development.
+Set `CCHH_TEST_ENVIRONMENT=1` to disable external notifications during development.
 
 ## Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -22,33 +22,33 @@ My personal Claude Code hook handlers for Slack notifications and voice feedback
 uv sync
 
 # Configure environment variables
-export SLACK_BOT_TOKEN="xoxb-your-token"
-export SLACK_CHANNEL_ID="C0123456789"
+export CCHH_SLACK_BOT_TOKEN="xoxb-your-token"
+export CCHH_SLACK_CHANNEL_ID="C0123456789"
 ```
 
 ## Environment Variables
 
 ### Slack Configuration
-- `SLACK_BOT_TOKEN`: Slack Bot Token (xoxb-...)
-- `SLACK_CHANNEL_ID`: Notification channel ID
-- `SLACK_NOTIFICATIONS_ENABLED`: Enable/disable Slack notifications (default: true)
-- `SLACK_SHOW_SESSION_START`: Show cwd on session start (default: true)
-- `SLACK_NOTIFY_ON_TOOL_USE`: Notify on tool usage (default: true)
-- `SLACK_NOTIFY_ON_STOP`: Notify on stop events (default: true)
-- `SLACK_COMMAND_MAX_LENGTH`: Max command display length (default: 200)
+- `CCHH_SLACK_BOT_TOKEN`: Slack Bot Token (xoxb-...)
+- `CCHH_SLACK_CHANNEL_ID`: Notification channel ID
+- `CCHH_SLACK_NOTIFICATIONS_ENABLED`: Enable/disable Slack notifications (default: true)
+- `CCHH_SLACK_SHOW_SESSION_START`: Show cwd on session start (default: true)
+- `CCHH_SLACK_NOTIFY_ON_TOOL_USE`: Notify on tool usage (default: true)
+- `CCHH_SLACK_NOTIFY_ON_STOP`: Notify on stop events (default: true)
+- `CCHH_SLACK_COMMAND_MAX_LENGTH`: Max command display length (default: 200)
 
 ### Zunda Voice Configuration
-- `ZUNDA_SPEAKER_ENABLED`: Enable/disable voice feedback (default: true)
-- `ZUNDA_SPEAK_ON_PROMPT_SUBMIT`: Speak on prompt submit (default: true)
-- `ZUNDA_SPEAK_SPEED`: Speech speed (default: 1.2)
+- `CCHH_ZUNDA_SPEAKER_ENABLED`: Enable/disable voice feedback (default: true)
+- `CCHH_ZUNDA_SPEAK_ON_PROMPT_SUBMIT`: Speak on prompt submit (default: true)
 
 ### Event Logging Configuration
-- `EVENT_LOGGING_ENABLED`: Enable/disable event logging (default: true)
-- `LOG_MAX_SIZE_MB`: Max log file size in MB (default: 100)
-- `LOG_ROTATION_COUNT`: Log rotation count (default: 5)
+- `CCHH_EVENT_LOGGING_ENABLED`: Enable/disable event logging (default: true)
+- `CCHH_LOG_MAX_SIZE_MB`: Max log file size in MB (default: 100)
+- `CCHH_LOG_ROTATION_COUNT`: Log rotation count (default: 5)
 
 ### Other
-- `TEST_ENVIRONMENT`: Test environment flag (disables notifications during tests)
+- `CCHH_TEST_ENVIRONMENT`: Test environment flag (disables notifications during tests)
+- `CCHH_CLAUDE_SESSION_ID`: Claude session ID
 
 ## Claude Code Integration
 

--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -16,7 +16,7 @@ class EventDispatcher:
 
     def _init_slack(self) -> HookHandler | None:
         """Initialize Slack notifier if enabled"""
-        if os.getenv("SLACK_NOTIFICATIONS_ENABLED", "true").lower() == "true":
+        if os.getenv("CCHH_SLACK_NOTIFICATIONS_ENABLED", "true").lower() == "true":
             try:
                 from ..slack.notifier import SlackNotifier
 
@@ -28,7 +28,7 @@ class EventDispatcher:
 
     def _init_zunda(self) -> HookHandler | None:
         """Initialize Zunda speaker if enabled"""
-        if os.getenv("ZUNDA_SPEAKER_ENABLED", "true").lower() == "true":
+        if os.getenv("CCHH_ZUNDA_SPEAKER_ENABLED", "true").lower() == "true":
             try:
                 from ..zunda.speaker import ZundaSpeaker
 
@@ -40,7 +40,7 @@ class EventDispatcher:
 
     def _init_logger(self) -> HookHandler | None:
         """Initialize event logger if enabled"""
-        if os.getenv("EVENT_LOGGING_ENABLED", "true").lower() == "true":
+        if os.getenv("CCHH_EVENT_LOGGING_ENABLED", "true").lower() == "true":
             try:
                 from ..logger.event_logger import EventLogger
 

--- a/src/logger/config.py
+++ b/src/logger/config.py
@@ -9,7 +9,7 @@ class LoggerConfig:
 
     def __init__(self):
         # Logger settings
-        self.enabled = self._get_bool_env("EVENT_LOGGING_ENABLED", True)
+        self.enabled = self._get_bool_env("CCHH_EVENT_LOGGING_ENABLED", True)
 
         # Log file locations
         self.log_dir = Path.home() / ".cchh" / "logs"
@@ -17,9 +17,9 @@ class LoggerConfig:
 
         self.event_log_file = self.log_dir / "events.jsonl"
         self.max_log_size = (
-            int(os.environ.get("LOG_MAX_SIZE_MB", "100")) * 1024 * 1024
+            int(os.environ.get("CCHH_LOG_MAX_SIZE_MB", "100")) * 1024 * 1024
         )  # MB to bytes
-        self.log_rotation_count = int(os.environ.get("LOG_ROTATION_COUNT", "5"))
+        self.log_rotation_count = int(os.environ.get("CCHH_LOG_ROTATION_COUNT", "5"))
 
     def _get_bool_env(self, key: str, default: bool) -> bool:
         """Get boolean value from environment variable"""

--- a/src/slack/config.py
+++ b/src/slack/config.py
@@ -38,14 +38,14 @@ class RuntimeConfig:
         thread_dir = Path.home() / ".cchh" / "slack_threads"
 
         return cls(
-            is_test_environment=os.getenv("TEST_ENVIRONMENT", "").lower() == "true",
-            notifications_enabled=_get_bool_env("SLACK_NOTIFICATIONS_ENABLED", True),
-            show_session_start=_get_bool_env("SLACK_SHOW_SESSION_START", True),
-            notify_on_tool_use=_get_bool_env("SLACK_NOTIFY_ON_TOOL_USE", True),
-            notify_on_stop=_get_bool_env("SLACK_NOTIFY_ON_STOP", True),
-            bot_token=os.environ.get("SLACK_BOT_TOKEN"),
-            channel_id=os.environ.get("SLACK_CHANNEL_ID"),
-            command_max_length=int(os.environ.get("SLACK_COMMAND_MAX_LENGTH", "200")),
+            is_test_environment=os.getenv("CCHH_TEST_ENVIRONMENT", "").lower() == "true",
+            notifications_enabled=_get_bool_env("CCHH_SLACK_NOTIFICATIONS_ENABLED", True),
+            show_session_start=_get_bool_env("CCHH_SLACK_SHOW_SESSION_START", True),
+            notify_on_tool_use=_get_bool_env("CCHH_SLACK_NOTIFY_ON_TOOL_USE", True),
+            notify_on_stop=_get_bool_env("CCHH_SLACK_NOTIFY_ON_STOP", True),
+            bot_token=os.environ.get("CCHH_SLACK_BOT_TOKEN"),
+            channel_id=os.environ.get("CCHH_SLACK_CHANNEL_ID"),
+            command_max_length=int(os.environ.get("CCHH_SLACK_COMMAND_MAX_LENGTH", "200")),
             thread_dir=thread_dir,
         )
 
@@ -60,15 +60,15 @@ class SlackConfig:
 
     def __init__(self):
         # Slack settings
-        self.enabled = self._get_bool_env("SLACK_NOTIFICATIONS_ENABLED", True)
-        self.bot_token = os.environ.get("SLACK_BOT_TOKEN")
-        self.channel_id = os.environ.get("SLACK_CHANNEL_ID")
+        self.enabled = self._get_bool_env("CCHH_SLACK_NOTIFICATIONS_ENABLED", True)
+        self.bot_token = os.environ.get("CCHH_SLACK_BOT_TOKEN")
+        self.channel_id = os.environ.get("CCHH_SLACK_CHANNEL_ID")
 
         # Slack feature toggles
-        self.show_session_start = self._get_bool_env("SLACK_SHOW_SESSION_START", True)
-        self.notify_on_tool_use = self._get_bool_env("SLACK_NOTIFY_ON_TOOL_USE", True)
-        self.notify_on_stop = self._get_bool_env("SLACK_NOTIFY_ON_STOP", True)
-        self.command_max_length = int(os.environ.get("SLACK_COMMAND_MAX_LENGTH", "200"))
+        self.show_session_start = self._get_bool_env("CCHH_SLACK_SHOW_SESSION_START", True)
+        self.notify_on_tool_use = self._get_bool_env("CCHH_SLACK_NOTIFY_ON_TOOL_USE", True)
+        self.notify_on_stop = self._get_bool_env("CCHH_SLACK_NOTIFY_ON_STOP", True)
+        self.command_max_length = int(os.environ.get("CCHH_SLACK_COMMAND_MAX_LENGTH", "200"))
 
         # Thread management directory
         self.thread_dir = Path.home() / ".cchh" / "slack_threads"

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 def is_test_environment() -> bool:
     """Check if running in test environment"""
-    return os.environ.get("TEST_ENVIRONMENT", "").lower() in ("1", "true", "yes")
+    return os.environ.get("CCHH_TEST_ENVIRONMENT", "").lower() in ("1", "true", "yes")
 
 
 def get_cchh_home() -> Path:
@@ -18,4 +18,4 @@ def get_cchh_home() -> Path:
 
 def get_session_id_from_env() -> str:
     """Get session ID from environment or generate default"""
-    return os.environ.get("CLAUDE_SESSION_ID", "default")
+    return os.environ.get("CCHH_CLAUDE_SESSION_ID", "default")

--- a/src/zunda/config.py
+++ b/src/zunda/config.py
@@ -22,11 +22,10 @@ class ZundaConfig:
 
     def __init__(self):
         # Zunda settings
-        self.enabled = self._get_bool_env("ZUNDA_SPEAKER_ENABLED", True)
+        self.enabled = self._get_bool_env("CCHH_ZUNDA_SPEAKER_ENABLED", True)
         self.speak_on_prompt_submit = self._get_bool_env(
-            "ZUNDA_SPEAK_ON_PROMPT_SUBMIT", True
+            "CCHH_ZUNDA_SPEAK_ON_PROMPT_SUBMIT", True
         )
-        self.speak_speed = float(os.environ.get("ZUNDA_SPEAK_SPEED", "1.2"))
         self.default_style = ZundaspeakStyle.NORMAL
 
         # Silent commands (commands that should not be spoken)

--- a/src/zunda/speaker.py
+++ b/src/zunda/speaker.py
@@ -109,7 +109,7 @@ class ZundaSpeaker(BaseHandler):
                 # Debug log for voice synthesis (only in non-test environment)
                 if (
                     not self._is_test_environment()
-                    and os.getenv("ZUNDA_DEBUG", "").lower() == "true"
+                    and os.getenv("CCHH_ZUNDA_DEBUG", "").lower() == "true"
                 ):
                     debug_log_path = os.path.join(os.getcwd(), "zunda_debug.log")
                     with open(debug_log_path, "a", encoding="utf-8") as f:
@@ -189,4 +189,4 @@ class ZundaSpeaker(BaseHandler):
 
     def _is_test_environment(self) -> bool:
         """Check if running in test environment"""
-        return os.environ.get("TEST_ENVIRONMENT", "").lower() in ("1", "true", "yes")
+        return os.environ.get("CCHH_TEST_ENVIRONMENT", "").lower() in ("1", "true", "yes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,13 +14,13 @@ sys.path.insert(0, str(project_root))
 @pytest.fixture(autouse=True)
 def test_environment():
     """Automatically set TEST_ENVIRONMENT for all tests"""
-    original = os.environ.get("TEST_ENVIRONMENT")
-    os.environ["TEST_ENVIRONMENT"] = "true"
+    original = os.environ.get("CCHH_TEST_ENVIRONMENT")
+    os.environ["CCHH_TEST_ENVIRONMENT"] = "true"
     yield
     if original is None:
-        os.environ.pop("TEST_ENVIRONMENT", None)
+        os.environ.pop("CCHH_TEST_ENVIRONMENT", None)
     else:
-        os.environ["TEST_ENVIRONMENT"] = original
+        os.environ["CCHH_TEST_ENVIRONMENT"] = original
 
 
 @pytest.fixture
@@ -40,21 +40,20 @@ def temp_log_dir(tmp_path):
 @pytest.fixture
 def mock_slack_config(monkeypatch):
     """Mock Slack configuration"""
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
-    monkeypatch.setenv("SLACK_CHANNEL_ID", "C1234567890")
-    monkeypatch.setenv("SLACK_NOTIFICATIONS_ENABLED", "true")
+    monkeypatch.setenv("CCHH_SLACK_BOT_TOKEN", "xoxb-test-token")
+    monkeypatch.setenv("CCHH_SLACK_CHANNEL_ID", "C1234567890")
+    monkeypatch.setenv("CCHH_SLACK_NOTIFICATIONS_ENABLED", "true")
 
 
 @pytest.fixture
 def mock_zunda_config(monkeypatch):
     """Mock Zunda configuration"""
-    monkeypatch.setenv("ZUNDA_SPEAKER_ENABLED", "true")
-    monkeypatch.setenv("ZUNDA_SPEAK_SPEED", "1.2")
+    monkeypatch.setenv("CCHH_ZUNDA_SPEAKER_ENABLED", "true")
 
 
 @pytest.fixture
 def disable_all_features(monkeypatch):
     """Disable all notification features"""
-    monkeypatch.setenv("SLACK_NOTIFICATIONS_ENABLED", "false")
-    monkeypatch.setenv("ZUNDA_SPEAKER_ENABLED", "false")
-    monkeypatch.setenv("EVENT_LOGGING_ENABLED", "false")
+    monkeypatch.setenv("CCHH_SLACK_NOTIFICATIONS_ENABLED", "false")
+    monkeypatch.setenv("CCHH_ZUNDA_SPEAKER_ENABLED", "false")
+    monkeypatch.setenv("CCHH_EVENT_LOGGING_ENABLED", "false")

--- a/tests/core/test_dispatcher.py
+++ b/tests/core/test_dispatcher.py
@@ -27,9 +27,9 @@ def mock_event():
 class TestEventDispatcher:
     """Test cases for EventDispatcher"""
 
-    @patch.dict(os.environ, {"SLACK_NOTIFICATIONS_ENABLED": "false"})
-    @patch.dict(os.environ, {"ZUNDA_SPEAKER_ENABLED": "false"})
-    @patch.dict(os.environ, {"EVENT_LOGGING_ENABLED": "false"})
+    @patch.dict(os.environ, {"CCHH_SLACK_NOTIFICATIONS_ENABLED": "false"})
+    @patch.dict(os.environ, {"CCHH_ZUNDA_SPEAKER_ENABLED": "false"})
+    @patch.dict(os.environ, {"CCHH_EVENT_LOGGING_ENABLED": "false"})
     def test_all_features_disabled(self):
         """Test dispatcher with all features disabled"""
         dispatcher = EventDispatcher()
@@ -38,7 +38,7 @@ class TestEventDispatcher:
         assert dispatcher.logger is None
 
     @patch("src.slack.notifier.SlackNotifier")
-    @patch.dict(os.environ, {"SLACK_NOTIFICATIONS_ENABLED": "true"})
+    @patch.dict(os.environ, {"CCHH_SLACK_NOTIFICATIONS_ENABLED": "true"})
     def test_slack_enabled(self, mock_slack_class):
         """Test dispatcher with Slack enabled"""
         mock_slack = MagicMock()
@@ -48,7 +48,7 @@ class TestEventDispatcher:
         assert dispatcher.slack is mock_slack
 
     @patch("src.zunda.speaker.ZundaSpeaker")
-    @patch.dict(os.environ, {"ZUNDA_SPEAKER_ENABLED": "true"})
+    @patch.dict(os.environ, {"CCHH_ZUNDA_SPEAKER_ENABLED": "true"})
     def test_zunda_enabled(self, mock_zunda_class):
         """Test dispatcher with Zunda enabled"""
         mock_zunda = MagicMock()
@@ -58,7 +58,7 @@ class TestEventDispatcher:
         assert dispatcher.zunda is mock_zunda
 
     @patch("src.logger.event_logger.EventLogger")
-    @patch.dict(os.environ, {"EVENT_LOGGING_ENABLED": "true"})
+    @patch.dict(os.environ, {"CCHH_EVENT_LOGGING_ENABLED": "true"})
     def test_logger_enabled(self, mock_logger_class):
         """Test dispatcher with Logger enabled"""
         mock_logger = MagicMock()
@@ -135,7 +135,7 @@ class TestEventDispatcher:
         dispatcher.dispatch(mock_event)
 
     @patch("src.slack.notifier.SlackNotifier", side_effect=ImportError)
-    @patch.dict(os.environ, {"SLACK_NOTIFICATIONS_ENABLED": "true"})
+    @patch.dict(os.environ, {"CCHH_SLACK_NOTIFICATIONS_ENABLED": "true"})
     def test_slack_import_error(self, mock_slack_class, capsys):
         """Test handling of Slack import error"""
         dispatcher = EventDispatcher()
@@ -145,7 +145,7 @@ class TestEventDispatcher:
         assert "Warning: Slack module not found" in captured.out
 
     @patch("src.zunda.speaker.ZundaSpeaker", side_effect=ImportError)
-    @patch.dict(os.environ, {"ZUNDA_SPEAKER_ENABLED": "true"})
+    @patch.dict(os.environ, {"CCHH_ZUNDA_SPEAKER_ENABLED": "true"})
     def test_zunda_import_error(self, mock_zunda_class, capsys):
         """Test handling of Zunda import error"""
         dispatcher = EventDispatcher()
@@ -155,7 +155,7 @@ class TestEventDispatcher:
         assert "Warning: Zunda module not found" in captured.out
 
     @patch("src.logger.event_logger.EventLogger", side_effect=ImportError)
-    @patch.dict(os.environ, {"EVENT_LOGGING_ENABLED": "true"})
+    @patch.dict(os.environ, {"CCHH_EVENT_LOGGING_ENABLED": "true"})
     def test_logger_import_error(self, mock_logger_class, capsys):
         """Test handling of Logger import error"""
         dispatcher = EventDispatcher()

--- a/tests/integration/test_all_hooks.py
+++ b/tests/integration/test_all_hooks.py
@@ -88,7 +88,7 @@ class TestAllHooksIntegration:
             env.update(env_vars)
 
         # Always set TEST_ENVIRONMENT to avoid actual notifications
-        env["TEST_ENVIRONMENT"] = "true"
+        env["CCHH_TEST_ENVIRONMENT"] = "true"
 
         cmd = [sys.executable, "all_hooks.py"]
 
@@ -119,9 +119,9 @@ class TestAllHooksIntegration:
     def test_all_features_disabled(self, sample_events):
         """Test execution with all features disabled"""
         env_vars = {
-            "SLACK_NOTIFICATIONS_ENABLED": "false",
-            "ZUNDA_SPEAKER_ENABLED": "false",
-            "EVENT_LOGGING_ENABLED": "false",
+            "CCHH_SLACK_NOTIFICATIONS_ENABLED": "false",
+            "CCHH_ZUNDA_SPEAKER_ENABLED": "false",
+            "CCHH_EVENT_LOGGING_ENABLED": "false",
         }
 
         result = self.run_all_hooks(sample_events["bash_command"], env_vars)
@@ -134,9 +134,9 @@ class TestAllHooksIntegration:
     def test_with_zunda_enabled(self, sample_events):
         """Test with Zunda speaker enabled"""
         env_vars = {
-            "SLACK_NOTIFICATIONS_ENABLED": "false",
-            "ZUNDA_SPEAKER_ENABLED": "true",
-            "EVENT_LOGGING_ENABLED": "false",
+            "CCHH_SLACK_NOTIFICATIONS_ENABLED": "false",
+            "CCHH_ZUNDA_SPEAKER_ENABLED": "true",
+            "CCHH_EVENT_LOGGING_ENABLED": "false",
         }
 
         # Run all_hooks with subprocess
@@ -183,11 +183,11 @@ class TestAllHooksIntegration:
         log_dir.mkdir()
 
         env_vars = {
-            "SLACK_NOTIFICATIONS_ENABLED": "false",
-            "ZUNDA_SPEAKER_ENABLED": "false",
-            "EVENT_LOGGING_ENABLED": "true",
+            "CCHH_SLACK_NOTIFICATIONS_ENABLED": "false",
+            "CCHH_ZUNDA_SPEAKER_ENABLED": "false",
+            "CCHH_EVENT_LOGGING_ENABLED": "true",
             "CCHH_LOG_DIR": str(log_dir),
-            "TEST_ENVIRONMENT": "false",  # Ensure logging happens
+            "CCHH_TEST_ENVIRONMENT": "false",  # Ensure logging happens
         }
 
         result = self.run_all_hooks(sample_events["bash_command"], env_vars)

--- a/tests/logger/test_event_logger.py
+++ b/tests/logger/test_event_logger.py
@@ -36,7 +36,7 @@ class TestEventLogger:
 
     def test_logger_disabled(self, sample_event, monkeypatch, temp_log_dir):
         """Test that disabled logger doesn't write files"""
-        monkeypatch.setenv("EVENT_LOGGING_ENABLED", "false")
+        monkeypatch.setenv("CCHH_EVENT_LOGGING_ENABLED", "false")
         logger = EventLogger(log_file=temp_log_dir / "test.jsonl")
         logger.handle_event(sample_event)
 

--- a/tests/slack/test_notifier.py
+++ b/tests/slack/test_notifier.py
@@ -62,15 +62,15 @@ class TestSlackNotifier:
     def setup_method(self):
         """Setup before each test"""
         # Store original TEST_ENVIRONMENT value
-        self.original_test_env = os.environ.get("TEST_ENVIRONMENT")
+        self.original_test_env = os.environ.get("CCHH_TEST_ENVIRONMENT")
 
     def teardown_method(self):
         """Cleanup after each test"""
         # Restore original TEST_ENVIRONMENT value
         if self.original_test_env is None:
-            os.environ.pop("TEST_ENVIRONMENT", None)
+            os.environ.pop("CCHH_TEST_ENVIRONMENT", None)
         else:
-            os.environ["TEST_ENVIRONMENT"] = self.original_test_env
+            os.environ["CCHH_TEST_ENVIRONMENT"] = self.original_test_env
 
     def test_disabled_notifier(self, slack_notifier, mock_event):
         """Test that disabled notifier doesn't send notifications"""

--- a/tests/zunda/test_speaker.py
+++ b/tests/zunda/test_speaker.py
@@ -226,7 +226,7 @@ class TestZundaSpeaker:
 
     def test_disabled_via_env(self):
         """Test that speaker can be disabled via environment"""
-        with patch.dict(os.environ, {"ZUNDA_SPEAKER_ENABLED": "false"}, clear=True):
+        with patch.dict(os.environ, {"CCHH_ZUNDA_SPEAKER_ENABLED": "false"}, clear=True):
             # Need to re-import the config to pick up the environment variable
             with patch("src.zunda.speaker.zunda_config") as mock_config:
                 mock_config.enabled = False


### PR DESCRIPTION
## Summary
- Add `CCHH_` prefix to all environment variables to avoid naming conflicts with other tools
- Remove unused `ZUNDA_SPEAK_SPEED` environment variable
- Add new `CCHH_ZUNDA_DEBUG` environment variable for debugging

## Details

This PR addresses issue #5 by adding the `CCHH_` prefix to all environment variables used by this tool. This change prevents potential naming conflicts with other tools that might use similar environment variable names.

### Changed Environment Variables

**Slack Configuration:**
- `SLACK_BOT_TOKEN` → `CCHH_SLACK_BOT_TOKEN`
- `SLACK_CHANNEL_ID` → `CCHH_SLACK_CHANNEL_ID`
- `SLACK_NOTIFICATIONS_ENABLED` → `CCHH_SLACK_NOTIFICATIONS_ENABLED`
- `SLACK_SHOW_SESSION_START` → `CCHH_SLACK_SHOW_SESSION_START`
- `SLACK_NOTIFY_ON_TOOL_USE` → `CCHH_SLACK_NOTIFY_ON_TOOL_USE`
- `SLACK_NOTIFY_ON_STOP` → `CCHH_SLACK_NOTIFY_ON_STOP`
- `SLACK_COMMAND_MAX_LENGTH` → `CCHH_SLACK_COMMAND_MAX_LENGTH`

**Zunda Configuration:**
- `ZUNDA_SPEAKER_ENABLED` → `CCHH_ZUNDA_SPEAKER_ENABLED`
- `ZUNDA_SPEAK_ON_PROMPT_SUBMIT` → `CCHH_ZUNDA_SPEAK_ON_PROMPT_SUBMIT`
- `ZUNDA_SPEAK_SPEED` → Removed (zundaspeak doesn't support speed control)

**Event Logging Configuration:**
- `EVENT_LOGGING_ENABLED` → `CCHH_EVENT_LOGGING_ENABLED`
- `LOG_MAX_SIZE_MB` → `CCHH_LOG_MAX_SIZE_MB`
- `LOG_ROTATION_COUNT` → `CCHH_LOG_ROTATION_COUNT`

**Other:**
- `TEST_ENVIRONMENT` → `CCHH_TEST_ENVIRONMENT`
- `CLAUDE_SESSION_ID` → `CCHH_CLAUDE_SESSION_ID`
- Added: `CCHH_ZUNDA_DEBUG` (for debugging voice synthesis)

## Test Plan
- [x] All unit tests pass
- [x] Linting passes
- [x] Type checking passes
- [x] Documentation updated

## Breaking Changes
⚠️ **This is a breaking change** - All environment variables now require the `CCHH_` prefix.

Users will need to update their environment variable configurations after updating to this version.

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)