### PR TITLE
chore(ci): pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@93df09fd88688c19bd9e4ca40e5c7281cba39ed1 # v0.0.40
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@93df09fd88688c19bd9e4ca40e5c7281cba39ed1 # v0.0.40
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- GitHub Actions を特定のコミットハッシュにピンニングして、サプライチェーンセキュリティを向上
- pinact を使用して自動的にピンニングを実施

## Changes
- `actions/checkout@v4` → `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
- `anthropics/claude-code-action@beta` → `anthropics/claude-code-action@93df09fd88688c19bd9e4ca40e5c7281cba39ed1` (v0.0.40)

## Test plan
- [ ] CI が正常に動作することを確認
- [ ] Claude Code Review が PR に対して動作することを確認
- [ ] Claude bot が @claude メンションに反応することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)