### PR TITLE
feat(claude): configure PostToolUse hook for ruff format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/yuya/src/github.com/yuya-takeyama/cchh && uv run python ruff_hook.py"
+            "command": "uv run python ruff_hook.py"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Configure PostToolUse hook for automatic ruff formatting
- Triggers on Write/Edit/MultiEdit operations for Python files
- Uses existing ruff_hook.py implementation
- cdなし設定で運用開始（問題があれば後で調整）

## Changes
- Added `.claude/settings.json` with PostToolUse hook configuration
- Hook executes `uv run python ruff_hook.py` after file edits
- Only applies to this Python project repository

## Test plan
- [x] Manual testing with debug mode confirmed hook execution
- [x] ruff_hook.py verified to work correctly
- [ ] Production testing with cdなし configuration

## Notes
Based on the article: https://zenn.dev/budougumi617/articles/claudecode-hooks-format-for-go

🤖 Generated with [Claude Code](https://claude.ai/code)