### PR TITLE
docs: 開発セットアップにaqua installを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ CCHH (Claude Code Hook Handlers) is a modular Python application that handles Cl
 
 ### Essential Commands
 ```bash
+# Install development tools (including uv)
+aqua install
+
 # Install dependencies
 uv sync
 
@@ -318,7 +321,7 @@ Add to Claude Code settings (`~/.claude/settings.json`):
 ### Common Issues
 1. **Import errors**: Ensure PYTHONPATH includes project root
 2. **Slack not working**: Check CCHH_SLACK_BOT_TOKEN and CCHH_SLACK_CHANNEL_ID
-3. **Tests failing**: Run `uv sync` to update dependencies
+3. **Tests failing**: Run `aqua install` then `uv sync` to update dependencies
 
 ### Debug Mode
 Set `CCHH_TEST_ENVIRONMENT=1` to disable external notifications during development.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ My personal Claude Code hook handlers for Slack notifications and voice feedback
 ## Setup
 
 ```bash
+# Install development tools (including uv)
+aqua install
+
 # Install dependencies
 uv sync
 


### PR DESCRIPTION
## 概要
開発環境のセットアップ手順に`aqua install`コマンドを追加しました。

## 変更内容
- README.mdとCLAUDE.mdの両方に`aqua install`の手順を追加
- トラブルシューティングセクションも更新

## 背景
[#12](https://github.com/yuya-takeyama/cchh/pull/12) でuvをaquaで管理するようになったため、開発者は最初に`aqua install`を実行してuvを含む開発ツールをインストールする必要があります。

Claude のレビューコメントで提案された改善を実装しました。

## 変更箇所
- README.md: セットアップ手順に`aqua install`を追加
- CLAUDE.md: 開発コマンドとトラブルシューティングに`aqua install`を追加

🤖 Generated with [Claude Code](https://claude.ai/code)